### PR TITLE
refactoring, support old accent style, and refine gi rules

### DIFF
--- a/examples/old_style.rs
+++ b/examples/old_style.rs
@@ -1,0 +1,20 @@
+extern crate vi;
+
+fn main() {
+    let inputs = "ra tajp hoas nhaf baf thuyr mua hoa hoef";
+
+    let words = inputs.split(' ');
+
+    let mut result = String::new();
+    for word in words {
+        vi::transform_buffer_with_style(
+            &vi::TELEX,
+            vi::processor::AccentStyle::Old,
+            word.chars(),
+            &mut result,
+        );
+        result.push(' ');
+    }
+
+    println!("{}", result); // prints "ra tạp hóa nhà bà thủy mua hoa hòe"
+}

--- a/src/editing.rs
+++ b/src/editing.rs
@@ -1,14 +1,14 @@
 //! Functions used for character editing.
 //!
-//! These functions work directly with character & string instead of the abstract word struct.
+//! These functions work directly with character & string instead of the abstract syllable struct.
 use crate::{
     maps::{
         ACCUTE_MAP, BREVE_MAP, CIRCUMFLEX_MAP, DOT_MAP, DYET_MAP, GRAVE_MAP, HOOK_ABOVE_MAP,
         HORN_MAP, TILDE_MAP,
     },
-    parsing::parse_word,
+    parsing::parse_syllable,
     processor::{LetterModification, ToneMark},
-    word::Word,
+    syllable::Syllable,
 };
 
 const SPECIAL_VOWEL_PAIRS: [&str; 6] = ["oa", "oe", "oo", "uy", "uo", "ie"];
@@ -18,14 +18,14 @@ const SPECIAL_VOWEL_PAIRS: [&str; 6] = ["oa", "oe", "oo", "uy", "uo", "ie"];
 /// # Rules:
 /// 1. If a vowel contains ơ or ê, tone mark goes there
 /// 2. If a vowel contains `oa`, `oe`, `oo`, `oy`, tone mark should be on the
-/// second character
+///    second character
 /// 3. If a vowel end with 2 put it on the first one
 /// 4. Else, but tone mark on second vowel character
-pub fn get_tone_mark_placement(raw_word: &str) -> usize {
-    let (_, word) = parse_word(raw_word).unwrap();
-    let vowel = &word.vowel;
+pub fn get_tone_mark_placement(raw_syllable: &str) -> usize {
+    let (_, syllable) = parse_syllable(raw_syllable).unwrap();
+    let vowel = &syllable.vowel;
     let vowel_len = vowel.chars().count();
-    let vowel_index = word.initial_consonant.chars().count();
+    let vowel_index = syllable.initial_consonant.chars().count();
     // If there's only one vowel, then it's guaranteed that the tone mark will go there
     if vowel_len == 1 {
         return vowel_index;
@@ -51,8 +51,8 @@ pub fn get_tone_mark_placement(raw_word: &str) -> usize {
         return vowel_index + 1;
     }
 
-    // If a word end with 2 character vowel, put it on the first character
-    if word.final_consonant.is_empty() && vowel_len == 2 {
+    // If a syllable end with 2 character vowel, put it on the first character
+    if syllable.final_consonant.is_empty() && vowel_len == 2 {
         return vowel_index;
     }
 
@@ -109,18 +109,18 @@ pub fn add_modification_char(ch: char, modification: &LetterModification) -> cha
 /// 2. If the modification is Circumflex, it's always on a, o, or e, which ever come first.
 /// 3. If the modification is Breve, it's always on a.
 /// 4. If the modification is Horn:
-///     a. if the vowel is oa, ignore
-///     b. if the vowel is uo & only the initial consonant is present, then it's on the o
-///     c. if the vowel is uo, uoi or uou, then it's on the first two chars
-///     d. if the vowel contains u then it's on u, otherwise if it contains o then it's on o
-pub fn get_modification_positions(word: &Word, modification: &LetterModification) -> Vec<usize> {
+///    a. if the vowel is oa, ignore
+///    b. if the vowel is uo & only the initial consonant is present, then it's on the o
+///    c. if the vowel is uo, uoi or uou, then it's on the first two chars
+///    d. if the vowel contains u then it's on u, otherwise if it contains o then it's on o
+pub fn get_modification_positions(syllable: &Syllable, modification: &LetterModification) -> Vec<usize> {
     if let LetterModification::Dyet = modification {
         return vec![0];
     }
 
-    let vowel_index = word.initial_consonant.chars().count();
+    let vowel_index = syllable.initial_consonant.chars().count();
 
-    let vowel = word.vowel.to_lowercase();
+    let vowel = syllable.vowel.to_lowercase();
 
     if let LetterModification::Circumflex = modification {
         let indexes = [vowel.find('a'), vowel.find('o'), vowel.find('e')]
@@ -149,7 +149,7 @@ pub fn get_modification_positions(word: &Word, modification: &LetterModification
             return Vec::new();
         }
 
-        if vowel == "uo" && !word.initial_consonant.is_empty() && word.final_consonant.is_empty() {
+        if vowel == "uo" && !syllable.initial_consonant.is_empty() && syllable.final_consonant.is_empty() {
             return vec![vowel_index + 1];
         }
 

--- a/src/editing.rs
+++ b/src/editing.rs
@@ -171,7 +171,10 @@ pub fn get_modification_positions(
             return Vec::new();
         }
 
-        if vowel == "uo" && !syllable.initial_consonant.is_empty() && syllable.final_consonant.is_empty() {
+        if vowel == "uo"
+            && !syllable.initial_consonant.is_empty()
+            && syllable.final_consonant.is_empty()
+        {
             return vec![vowel_index + 1];
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@
 //! # Aspirations
 //!
 //! - Minimal to zero configuration. The engine should have a default configurations that fit with most usecases.
-//! - Support all transformation behaviours & orders. Adding a tonemark during or after typing a word should just work.
+//! - Support all transformation behaviours & orders. Adding a tonemark during or after typing a syllable should just work.
 //! - Be as fast as possible.
 //! - Be as simple as possible.
 //!
@@ -37,12 +37,12 @@ pub mod maps;
 pub mod methods;
 pub mod parsing;
 pub mod processor;
+pub mod syllable;
 #[deprecated(since = "0.7.0")]
 pub mod telex;
 pub mod util;
 pub mod validation;
 #[deprecated(since = "0.7.0")]
 pub mod vni;
-pub mod word;
 
 pub use methods::*;

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -320,4 +320,3 @@ where
 {
     transform_buffer_with_style(definition, AccentStyle::default(), buffer, output)
 }
-

--- a/src/methods.rs
+++ b/src/methods.rs
@@ -1,7 +1,7 @@
 //! The definitions of different typing methods.
 //!
 //! Normally, for IME developers, you only need these things from this module:
-//! - [`transform_buffer`] function to transfer your sequence of character into a word using a typing definition.
+//! - [`transform_buffer`] function to transfer your sequence of character into a syllable using a typing definition.
 //! - [`TELEX`] typing definition that you can use to pass in [`transform_buffer`] to transform character sequence using telex method.
 //! - [`VNI`] typing defnition that you can use to pass in [`transform_buffer`] to trasnform character sequence using vni method.
 //!
@@ -56,8 +56,8 @@ use crate::{
     processor::{
         add_tone, modify_letter, remove_tone, LetterModification, ToneMark, Transformation,
     },
-    validation::is_valid_word,
-    word::Word,
+    validation::is_valid_syllable,
+    syllable::Syllable,
 };
 
 /// An action to be listed as part of a typing definition.
@@ -71,11 +71,11 @@ pub enum Action {
     /// `ModifyLetterOnCharacterFamily(Circumflex, 'a')` will only apply circumflex
     /// modification if `a` or any character in the `a` family (`â`, `ă`).
     ModifyLetterOnCharacterFamily(LetterModification, char),
-    /// Insert an ư character at the end of the word.
+    /// Insert an ư character at the end of the syllable.
     InsertƯ,
-    /// Remove the last ư character inserted at the end of the word. **Note:** this only trigger if the last action is `InsertƯ`.
+    /// Remove the last ư character inserted at the end of the syllable. **Note:** this only trigger if the last action is `InsertƯ`.
     ResetInsertedƯ,
-    /// Remove the tonemark from the word.
+    /// Remove the tonemark from the syllable.
     RemoveToneMark,
 }
 
@@ -151,7 +151,7 @@ pub static VNI: Definition = phf_map! {
 /// - `z` -> RemoveToneMark bỏ dấu thanh (sắc, hỏi, ngã, huyền)
 ///
 /// **Note:**
-/// - By default `w` inserted by itself will be inserted as `ư` in the word.
+/// - By default `w` inserted by itself will be inserted as `ư` in the syllable.
 /// - An `u` followed by a `w` will produce: `ư`, and if you add another `w`, it will result in `uw`.
 /// - A `w` will produce `ư`, and if it's followed by a `w`, it will not produce `uw` but will replace `ư` with `w`.
 pub static TELEX: Definition = phf_map! {
@@ -187,7 +187,7 @@ pub fn transform_buffer<I>(
 where
     I: IntoIterator<Item = char>,
 {
-    let mut word = Word::empty();
+    let mut syllable = Syllable::empty();
     let mut tone_mark_removed = false;
     let mut letter_modification_removed = false;
 
@@ -198,11 +198,11 @@ where
 
         // If a character is not recognised as a transformation character in definition. Skip it.
         if !definition.contains_key(&lowercase_ch) {
-            word.push(ch);
+            syllable.push(ch);
             continue;
         }
 
-        let fallback = format!("{}{}", word, ch);
+        let fallback = format!("{}{}", syllable, ch);
         let actions = definition.get(&lowercase_ch).unwrap();
 
         let mut action_iter = actions.iter();
@@ -210,19 +210,19 @@ where
 
         loop {
             let transformation = match action {
-                Action::AddTonemark(tonemark) => add_tone(&mut word, tonemark),
-                Action::ModifyLetter(modification) => modify_letter(&mut word, modification),
+                Action::AddTonemark(tonemark) => add_tone(&mut syllable, tonemark),
+                Action::ModifyLetter(modification) => modify_letter(&mut syllable, modification),
                 Action::ModifyLetterOnCharacterFamily(modification, family_char)
-                    if word.vowel.to_ascii_lowercase().contains(*family_char) =>
+                    if syllable.vowel.to_ascii_lowercase().contains(*family_char) =>
                 {
-                    modify_letter(&mut word, modification)
+                    modify_letter(&mut syllable, modification)
                 }
-                Action::RemoveToneMark => remove_tone(&mut word),
+                Action::RemoveToneMark => remove_tone(&mut syllable),
                 Action::InsertƯ => {
-                    if word.vowel.is_empty() || word.to_string() == "gi" {
-                        word.push(if ch.is_lowercase() { 'u' } else { 'U' });
-                        let last_index = word.len() - 1;
-                        word.letter_modifications
+                    if syllable.vowel.is_empty() || syllable.to_string() == "gi" {
+                        syllable.push(if ch.is_lowercase() { 'u' } else { 'U' });
+                        let last_index = syllable.len() - 1;
+                        syllable.letter_modifications
                             .push((last_index, LetterModification::Horn));
                         Transformation::LetterModificationAdded
                     } else {
@@ -231,7 +231,7 @@ where
                 }
                 Action::ResetInsertedƯ if matches!(last_executed_action, Some(Action::InsertƯ)) =>
                 {
-                    word.replace_last_char(ch);
+                    syllable.replace_last_char(ch);
                     Transformation::LetterModificationRemoved
                 }
                 _ => Transformation::Ignored,
@@ -267,10 +267,10 @@ where
             }
 
             if !action_performed {
-                word.push(ch);
+                syllable.push(ch);
                 last_executed_action = None;
-            } else if !is_valid_word(&word.to_string()) {
-                word.set(fallback);
+            } else if !is_valid_syllable(&syllable.to_string()) {
+                syllable.set(fallback);
                 last_executed_action = None;
             } else {
                 last_executed_action = Some(action.clone());
@@ -279,7 +279,7 @@ where
         }
     }
 
-    output.push_str(&word.to_string());
+    output.push_str(&syllable.to_string());
 
     TransformResult {
         tone_mark_removed,

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -21,7 +21,7 @@ pub struct WordComponents<'a> {
 }
 
 fn initial_consonant(input: &str) -> IResult<&str, &str> {
-    if input.eq_ignore_ascii_case("gi") || input.eq_ignore_ascii_case("gin") {
+    if input.to_lowercase().starts_with("gi") && !input.chars().nth(2).is_some_and(is_vowel) {
         return tag_no_case("g")(input);
     }
     alt((tag_no_case("gi"), tag_no_case("qu"), take_till(is_vowel)))(input)

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,4 +1,4 @@
-//! Parser for parsing an input string as a Vietnamese word
+//! Parser for parsing an input string as a Vietnamese syllable
 use crate::{
     maps::{
         ACCUTE_MAP, BREVE_MAP, CIRCUMFLEX_MAP, DOT_MAP, DYET_MAP, GRAVE_MAP, HOOK_ABOVE_MAP,
@@ -14,7 +14,7 @@ use nom::{
     IResult,
 };
 
-pub struct WordComponents<'a> {
+pub struct SyllableComponents<'a> {
     pub initial_consonant: &'a str,
     pub vowel: &'a str,
     pub final_consonant: &'a str,
@@ -36,11 +36,11 @@ pub fn parse_vowel(input: &str) -> IResult<&str, &str> {
     Ok((rest, vowel))
 }
 
-pub fn parse_word(input: &str) -> IResult<&str, WordComponents<'_>> {
+pub fn parse_syllable(input: &str) -> IResult<&str, SyllableComponents<'_>> {
     let (rest, (initial_consonant, vowel)) = tuple((initial_consonant, vowel))(input)?;
     Ok((
         rest,
-        WordComponents {
+        SyllableComponents {
             initial_consonant,
             vowel,
             final_consonant: rest,

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -3,9 +3,9 @@
 //! The idea is both the telex & vni modules will use the transformation algorithms
 //! from this module to perform text transformation according to their method rules.
 use super::maps::{BREVE_MAP, CIRCUMFLEX_MAP, DYET_MAP, HORN_MAP};
-use crate::{editing::get_modification_positions, word::Word};
+use crate::{editing::get_modification_positions, syllable::Syllable};
 
-/// Maximum length of a Vietnamese "word" is 7 letters long (nghiêng)
+/// Maximum length of a Vietnamese "syllable" is 7 letters long (nghiêng)
 const MAX_WORD_LENGTH: usize = 7;
 
 /// Vietnamese's tone mark
@@ -39,18 +39,18 @@ pub enum LetterModification {
 /// A resulted transformation
 #[derive(Debug, PartialEq, Clone)]
 pub enum Transformation {
-    /// A tone mark has been successfully added on a "tone-less" word.
+    /// A tone mark has been successfully added on a "tone-less" syllable.
     ToneMarkAdded,
     /// A new tone mark has been placed to replace an existing tone mark.
     ToneMarkReplaced,
-    /// A tone mark has been removed from the word
+    /// A tone mark has been removed from the syllable
     ToneMarkRemoved,
 
-    /// A letter modification has been added on a word without removing any existing modification.
+    /// A letter modification has been added on a syllable without removing any existing modification.
     LetterModificationAdded,
     /// A letter modification has been added to replace an existing modification.
     LetterModificationReplaced,
-    /// A letter modification has been removed from the word
+    /// A letter modification has been removed from the syllable
     LetterModificationRemoved,
 
     /// The transformation cannot be applied and has been ignored
@@ -59,49 +59,49 @@ pub enum Transformation {
 
 /// Add tone mark to input.
 /// Return AddToneResult
-pub fn add_tone(word: &mut Word, tone_mark: &ToneMark) -> Transformation {
-    if word.is_empty() || word.len() > MAX_WORD_LENGTH {
+pub fn add_tone(syllable: &mut Syllable, tone_mark: &ToneMark) -> Transformation {
+    if syllable.is_empty() || syllable.len() > MAX_WORD_LENGTH {
         return Transformation::Ignored;
     }
 
-    if word.vowel.is_empty() {
+    if syllable.vowel.is_empty() {
         return Transformation::Ignored;
     }
 
-    if let Some(existing_tone_mark) = word.tone_mark.clone() {
+    if let Some(existing_tone_mark) = syllable.tone_mark.clone() {
         if existing_tone_mark == *tone_mark {
-            word.tone_mark = None;
+            syllable.tone_mark = None;
             Transformation::ToneMarkRemoved
         } else {
-            word.tone_mark = Some(tone_mark.clone());
+            syllable.tone_mark = Some(tone_mark.clone());
             Transformation::ToneMarkReplaced
         }
     } else {
-        word.tone_mark = Some(tone_mark.clone());
+        syllable.tone_mark = Some(tone_mark.clone());
         Transformation::ToneMarkAdded
     }
 }
 
 /// change a letter to vietnamese modified letter.
 /// Return if the letter has been modified or not and what's the output.
-pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Transformation {
-    if word.is_empty() || word.len() > MAX_WORD_LENGTH {
+pub fn modify_letter(syllable: &mut Syllable, modification: &LetterModification) -> Transformation {
+    if syllable.is_empty() || syllable.len() > MAX_WORD_LENGTH {
         return Transformation::Ignored;
     }
 
     // Remove the modification if it's already exist except for horn when two character with the same horn modification can exist
-    if word.contains_modification(modification) {
+    if syllable.contains_modification(modification) {
         // Special case where you don't remove the modification but add another one on top if possible
         if let LetterModification::Horn = modification {
-            let current_modifications: Vec<&(usize, LetterModification)> = word
+            let current_modifications: Vec<&(usize, LetterModification)> = syllable
                 .letter_modifications
                 .iter()
                 .filter(|(_, modification)| *modification == LetterModification::Horn)
                 .collect();
             let horn_modification_count = current_modifications.len();
 
-            let vowel = word.vowel.to_lowercase();
-            let vowel_index = word.initial_consonant.chars().count();
+            let vowel = syllable.vowel.to_lowercase();
+            let vowel_index = syllable.initial_consonant.chars().count();
             let modification_possibilities: Vec<usize> = [vowel.find('u'), vowel.find('o')]
                 .iter()
                 .filter_map(|index| index.map(|index| vowel_index + index))
@@ -118,13 +118,13 @@ pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Tran
                             .any(|(current_index, _)| *current_index != **index)
                     })
                     .unwrap();
-                word.letter_modifications
+                syllable.letter_modifications
                     .push((*other_modification_position, LetterModification::Horn));
                 return Transformation::LetterModificationAdded;
             }
         }
-        word.letter_modifications.remove(
-            word.letter_modifications
+        syllable.letter_modifications.remove(
+            syllable.letter_modifications
                 .iter()
                 .position(|(_, m)| m == modification)
                 .unwrap(),
@@ -134,9 +134,9 @@ pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Tran
 
     // Add the modification if it's dyet (because you can't replace dyet with anything, only add or remove)
     if *modification == LetterModification::Dyet {
-        if let Some(first_char) = word.initial_consonant.chars().next() {
+        if let Some(first_char) = syllable.initial_consonant.chars().next() {
             if DYET_MAP.contains_key(&first_char) {
-                word.letter_modifications
+                syllable.letter_modifications
                     .push((0, LetterModification::Dyet));
                 return Transformation::LetterModificationAdded;
             }
@@ -145,7 +145,7 @@ pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Tran
     }
 
     // Ignore special case
-    if *modification == LetterModification::Horn && word.vowel.to_lowercase() == "oa" {
+    if *modification == LetterModification::Horn && syllable.vowel.to_lowercase() == "oa" {
         return Transformation::Ignored;
     }
 
@@ -156,24 +156,24 @@ pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Tran
         LetterModification::Dyet => &DYET_MAP,
     };
 
-    // Add the modification if the word have no modification or only have dyet modification
-    if word.letter_modifications.is_empty()
-        || (word.letter_modifications.len() == 1
-            && word.contains_modification(&LetterModification::Dyet))
+    // Add the modification if the syllable have no modification or only have dyet modification
+    if syllable.letter_modifications.is_empty()
+        || (syllable.letter_modifications.len() == 1
+            && syllable.contains_modification(&LetterModification::Dyet))
     {
         // No letter can be transformed
-        if !word.vowel.contains(|c| map.contains_key(&c)) {
+        if !syllable.vowel.contains(|c| map.contains_key(&c)) {
             return Transformation::Ignored;
         }
 
-        let positions = get_modification_positions(word, modification);
+        let positions = get_modification_positions(syllable, modification);
 
         if positions.is_empty() {
             return Transformation::Ignored;
         }
 
         for position in positions {
-            word.letter_modifications
+            syllable.letter_modifications
                 .push((position, modification.clone()));
         }
 
@@ -181,23 +181,23 @@ pub fn modify_letter(word: &mut Word, modification: &LetterModification) -> Tran
     }
 
     // No letter can be transformed
-    if !word.vowel.contains(|c| map.contains_key(&c)) {
+    if !syllable.vowel.contains(|c| map.contains_key(&c)) {
         return Transformation::Ignored;
     }
 
     // Otherwise replace the modification
-    let positions = get_modification_positions(word, modification);
-    word.letter_modifications
+    let positions = get_modification_positions(syllable, modification);
+    syllable.letter_modifications
         .retain(|(_, modification)| *modification == LetterModification::Dyet);
     for position in positions {
-        word.letter_modifications
+        syllable.letter_modifications
             .push((position, modification.clone()));
     }
     Transformation::LetterModificationReplaced
 }
 
 /// Remove the tone for the letter
-pub fn remove_tone(input: &mut Word) -> Transformation {
+pub fn remove_tone(input: &mut Syllable) -> Transformation {
     if input.len() > MAX_WORD_LENGTH {
         return Transformation::Ignored;
     }

--- a/src/processor.rs
+++ b/src/processor.rs
@@ -23,6 +23,16 @@ pub enum ToneMark {
     Underdot,
 }
 
+/// Determines how accent marks are placed on syllables
+#[derive(Debug, PartialEq, Clone, Default)]
+pub enum AccentStyle {
+    /// Old-style accent placement rules.
+    Old,
+    /// New-style accent placement (default).
+    #[default]
+    New,
+}
+
 /// A modification to be apply to a letter
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
 pub enum LetterModification {
@@ -118,13 +128,15 @@ pub fn modify_letter(syllable: &mut Syllable, modification: &LetterModification)
                             .any(|(current_index, _)| *current_index != **index)
                     })
                     .unwrap();
-                syllable.letter_modifications
+                syllable
+                    .letter_modifications
                     .push((*other_modification_position, LetterModification::Horn));
                 return Transformation::LetterModificationAdded;
             }
         }
         syllable.letter_modifications.remove(
-            syllable.letter_modifications
+            syllable
+                .letter_modifications
                 .iter()
                 .position(|(_, m)| m == modification)
                 .unwrap(),
@@ -136,7 +148,8 @@ pub fn modify_letter(syllable: &mut Syllable, modification: &LetterModification)
     if *modification == LetterModification::Dyet {
         if let Some(first_char) = syllable.initial_consonant.chars().next() {
             if DYET_MAP.contains_key(&first_char) {
-                syllable.letter_modifications
+                syllable
+                    .letter_modifications
                     .push((0, LetterModification::Dyet));
                 return Transformation::LetterModificationAdded;
             }
@@ -173,7 +186,8 @@ pub fn modify_letter(syllable: &mut Syllable, modification: &LetterModification)
         }
 
         for position in positions {
-            syllable.letter_modifications
+            syllable
+                .letter_modifications
                 .push((position, modification.clone()));
         }
 
@@ -187,10 +201,12 @@ pub fn modify_letter(syllable: &mut Syllable, modification: &LetterModification)
 
     // Otherwise replace the modification
     let positions = get_modification_positions(syllable, modification);
-    syllable.letter_modifications
+    syllable
+        .letter_modifications
         .retain(|(_, modification)| *modification == LetterModification::Dyet);
     for position in positions {
-        syllable.letter_modifications
+        syllable
+            .letter_modifications
             .push((position, modification.clone()));
     }
     Transformation::LetterModificationReplaced

--- a/src/syllable.rs
+++ b/src/syllable.rs
@@ -1,59 +1,59 @@
-//! The cache for word transformation.
+//! The cache for syllable transformation.
 //!
-//! Since vi-rs work by looping through a list of character & apply transformation on a word,
-//! it's much more beneficial to store the current state of the word as a struct rather than
+//! Since vi-rs work by looping through a list of character & apply transformation on a syllable,
+//! it's much more beneficial to store the current state of the syllable as a struct rather than
 //! a string so it doesn't need to be parsed everytime a transformation is applied.
 //!
-//! Normally you'd start by constructing an empty word at the start of the process,
-//! and then perform various manipulations on the words. Afterwards, you can call `to_string()`
-//! to retrieve a String value representing the final state of the word.
+//! Normally you'd start by constructing an empty syllable at the start of the process,
+//! and then perform various manipulations on the syllables. Afterwards, you can call `to_string()`
+//! to retrieve a String value representing the final state of the syllable.
 //!
 //! ## Example:
 //!
 //! ```
-//! use vi::word::Word;
+//! use vi::syllable::Syllable;
 //! use vi::processor::{modify_letter, add_tone, LetterModification, ToneMark};
 //!
-//! let mut word = Word::empty();
-//! word.push('t');
-//! word.push('u');
-//! word.push('y');
-//! word.push('e');
-//! word.push('t');
+//! let mut syllable = Syllable::empty();
+//! syllable.push('t');
+//! syllable.push('u');
+//! syllable.push('y');
+//! syllable.push('e');
+//! syllable.push('t');
 //!
-//! modify_letter(&mut word, &LetterModification::Circumflex);
-//! add_tone(&mut word, &ToneMark::Acute);
+//! modify_letter(&mut syllable, &LetterModification::Circumflex);
+//! add_tone(&mut syllable, &ToneMark::Acute);
 //!
-//! println!("{}", word); // tuyết
+//! println!("{}", syllable); // tuyết
 //!
 //! ```
 use std::fmt::Display;
 
 use crate::{
     editing::{add_modification_char, add_tone_char, get_tone_mark_placement, replace_nth_char},
-    parsing::{extract_letter_modifications, extract_tone, parse_word},
+    parsing::{extract_letter_modifications, extract_tone, parse_syllable},
     processor::{modify_letter, LetterModification, ToneMark},
     util::clean_char,
 };
 
-/// Represent a word that is being transformed. This is so the word doesn't need to be re-parsed
-/// during transformation stage. After all transformation is applied, the final state of the word
+/// Represent a syllable that is being transformed. This is so the syllable doesn't need to be re-parsed
+/// during transformation stage. After all transformation is applied, the final state of the syllable
 /// can be retreieved via the `to_string` method.
-pub struct Word {
-    /// The initial consonant of the word. This is always a clean text with no transformation applied.
+pub struct Syllable {
+    /// The initial consonant of the syllable. This is always a clean text with no transformation applied.
     pub initial_consonant: String,
-    /// The vowel of the word. This is always a clean text with no transformation applied.
+    /// The vowel of the syllable. This is always a clean text with no transformation applied.
     pub vowel: String,
-    /// The final consonant of the word. This is always a clean text with no transformation applied.
+    /// The final consonant of the syllable. This is always a clean text with no transformation applied.
     pub final_consonant: String,
-    /// The tone mark of the word. This could be empty for word with no tone mark or "thanh ngang".
+    /// The tone mark of the syllable. This could be empty for syllable with no tone mark or "thanh ngang".
     pub tone_mark: Option<ToneMark>,
-    /// Letter modifications on the word, along with the index that the modification is applying to.
+    /// Letter modifications on the syllable, along with the index that the modification is applying to.
     pub letter_modifications: Vec<(usize, LetterModification)>,
 }
 
-impl Word {
-    /// Construct an empty word
+impl Syllable {
+    /// Construct an empty syllable
     pub fn empty() -> Self {
         Self {
             initial_consonant: String::new(),
@@ -64,37 +64,37 @@ impl Word {
         }
     }
 
-    /// The length of the word in characters instead of bytes.
+    /// The length of the syllable in characters instead of bytes.
     pub fn len(&self) -> usize {
         self.initial_consonant.chars().count()
             + self.vowel.chars().count()
             + self.final_consonant.chars().count()
     }
 
-    /// Indicate whether the word have no initial consonant, vowel & final consonant.
+    /// Indicate whether the syllable have no initial consonant, vowel & final consonant.
     pub fn is_empty(&self) -> bool {
         self.initial_consonant.is_empty()
             && self.vowel.is_empty()
             && self.final_consonant.is_empty()
     }
 
-    /// Push a character to the word. This will also trigger modification recalculation for the word.
+    /// Push a character to the syllable. This will also trigger modification recalculation for the syllable.
     pub fn push(&mut self, ch: char) {
-        let clean_word = format!(
+        let clean_syllable = format!(
             "{}{}{}{}",
             self.initial_consonant, self.vowel, self.final_consonant, ch
         );
-        let (_, word) = parse_word(&clean_word).unwrap();
-        self.initial_consonant = word.initial_consonant.chars().map(clean_char).collect();
-        self.vowel = word.vowel.chars().map(clean_char).collect();
-        self.final_consonant = word.final_consonant.to_string();
+        let (_, syllable) = parse_syllable(&clean_syllable).unwrap();
+        self.initial_consonant = syllable.initial_consonant.chars().map(clean_char).collect();
+        self.vowel = syllable.vowel.chars().map(clean_char).collect();
+        self.final_consonant = syllable.final_consonant.to_string();
 
         self.recalculate_modifications();
     }
 
-    /// Recalculate the position of the modification for the current word.
+    /// Recalculate the position of the modification for the current syllable.
     pub fn recalculate_modifications(&mut self) {
-        // consonants are required to recalculate, unless it's the word uoi
+        // consonants are required to recalculate, unless it's the syllable uoi
         if self.initial_consonant.is_empty()
             && self.final_consonant.is_empty()
             && !self.vowel.eq_ignore_ascii_case("uoi")
@@ -118,12 +118,12 @@ impl Word {
         }
     }
 
-    /// Set a new value for the current word. This will parse the value into consonants, vowel, tonemark & modifications.
+    /// Set a new value for the current syllable. This will parse the value into consonants, vowel, tonemark & modifications.
     pub fn set(&mut self, raw: String) {
-        let (_, word) = parse_word(&raw).unwrap();
-        self.initial_consonant = word.initial_consonant.chars().map(clean_char).collect();
-        self.vowel = word.vowel.chars().map(clean_char).collect();
-        self.final_consonant = word.final_consonant.to_string();
+        let (_, syllable) = parse_syllable(&raw).unwrap();
+        self.initial_consonant = syllable.initial_consonant.chars().map(clean_char).collect();
+        self.vowel = syllable.vowel.chars().map(clean_char).collect();
+        self.final_consonant = syllable.final_consonant.to_string();
 
         self.letter_modifications = extract_letter_modifications(&raw);
         self.tone_mark = extract_tone(&raw);
@@ -137,7 +137,7 @@ impl Word {
         self.set(raw);
     }
 
-    /// Indicate whether a modification exist in the word
+    /// Indicate whether a modification exist in the syllable
     pub fn contains_modification(&self, modification: &LetterModification) -> bool {
         self.letter_modifications
             .iter()
@@ -145,7 +145,7 @@ impl Word {
     }
 }
 
-impl Display for Word {
+impl Display for Syllable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut result = format!(
             "{}{}{}",
@@ -171,10 +171,10 @@ impl Display for Word {
 }
 
 #[cfg(test)]
-impl From<&str> for Word {
+impl From<&str> for Syllable {
     fn from(value: &str) -> Self {
-        let mut word = Word::empty();
-        word.set(value.to_string());
-        word
+        let mut syllable = Syllable::empty();
+        syllable.set(value.to_string());
+        syllable
     }
 }

--- a/src/telex.rs
+++ b/src/telex.rs
@@ -1,6 +1,6 @@
 use crate::TransformResult;
 
-/// Transform input buffer containing a single word to vietnamese string output using telex mode.
+/// Transform input buffer containing a single syllable to vietnamese string output using telex mode.
 ///
 /// # Example
 /// ```

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -1,6 +1,6 @@
-//! Validation functions for verifying if a word is a valid vietnamese word.
+//! Validation functions for verifying if a syllable is a valid vietnamese syllable.
 //!
-//! # The structure of a vietnamese word
+//! # The structure of a vietnamese syllable
 //!
 //! 1 optional consonant / consonant cluster + 1 compulsory vowel / vowel cluster + 1 optional consonant / consonant cluster
 //!
@@ -10,7 +10,7 @@
 
 use phf::{phf_set, Set};
 
-use crate::{parsing::parse_word, util::clean_char};
+use crate::{parsing::parse_syllable, util::clean_char};
 
 const SINGLE_INITIAL_CONSONANTS: Set<char> =
     phf_set!['b', 'c', 'd', 'đ', 'g', 'h', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'x',];
@@ -26,9 +26,9 @@ const VOWELS: Set<&'static str> = phf_set![
     "uye", "uoi", "ye", "yeu", "y", "eu", "ue", "uay"
 ];
 
-/// Verify if a word is a valid vietnamese word.
-pub fn is_valid_word(input: &str) -> bool {
-    let Ok((_, components)) = parse_word(input) else {
+/// Verify if a syllable is a valid vietnamese syllable.
+pub fn is_valid_syllable(input: &str) -> bool {
+    let Ok((_, components)) = parse_syllable(input) else {
         return false;
     };
 

--- a/src/validation.rs
+++ b/src/validation.rs
@@ -6,7 +6,7 @@
 //!
 //! The starting consonant are called initial consonant, while the consonant at the end is called the final consonant.
 //! A cluster of consonant can contains 1 -> 3 characters.
-//! See: https://en.wikibooks.org/wiki/Vietnamese/Consonants
+//! See: <https://en.wikibooks.org/wiki/Vietnamese/Consonants>
 
 use phf::{phf_set, Set};
 

--- a/src/vni.rs
+++ b/src/vni.rs
@@ -1,6 +1,6 @@
 use crate::TransformResult;
 
-/// Transform input buffer containing a single word to vietnamese string output using vni mode.
+/// Transform input buffer containing a single syllable to vietnamese string output using vni mode.
 ///
 /// # Example
 /// ```

--- a/testdata/output/telex__simple_telex.snap
+++ b/testdata/output/telex__simple_telex.snap
@@ -47,7 +47,7 @@ việt nam
 xuất hiện xuất hiện xuất hiện
 giàng ơi
 Giàng ơi
-ươ
+uơ
 ưo
 ươn
 hưo

--- a/testdata/output/telex__simple_telex.snap
+++ b/testdata/output/telex__simple_telex.snap
@@ -47,7 +47,7 @@ việt nam
 xuất hiện xuất hiện xuất hiện
 giàng ơi
 Giàng ơi
-uơ
+ươ
 ưo
 ươn
 hưo


### PR DESCRIPTION
I tried with [a list of possible Vietnamese syllables](https://github.com/phamvandong/All-Vietnamese-syllables-2022) that I found online.
Here are some small adjustments:
- `gi` should be a consonant only if it is followed by a vowel (for example `gích` in `lô gích`).
- ~`uờ` somehow is a valid Vietnamese word, although they are no longer commonly used, so checking if the initial consonant is empty may not be necessary here.~